### PR TITLE
Optimize Viewer: Single Diff Calculation with Dual Minimap Display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+todo.md
 
 node_modules
 dist

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
   ],
   "scripts": {
     "build": "bun run rollup",
+    "watch": "bun run rollup --watch",
     "prepublishOnly": "bun run build",
     "rollup": "rollup -c --bundleConfigAsCjs",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "demo:dev": "cd demo && npm run dev",
-    "demo:build": "cd demo && npm run build"
+    "demo:build": "cd demo && npm run build",
+    "dev:watch": "concurrently \"npm run watch\" \"npm run demo:dev\""
   },
   "peerDependencies": {
     "react": ">=18.0.0"
@@ -63,6 +65,7 @@
     "@types/node": "^22.14.1",
     "@types/react": ">=18.0.0",
     "@types/react-window": "^1.8.8",
+    "concurrently": "^8.2.2",
     "eslint": "^9.33.0",
     "eslint-plugin-format": "^1.0.1",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/components/DiffViewer/components/DiffMinimap.tsx
+++ b/src/components/DiffViewer/components/DiffMinimap.tsx
@@ -47,6 +47,7 @@ export const DiffMinimap: React.FC<DiffMinimapProps> = ({
 
   const { drawMinimap, drawScrollBox } = useMinimapDraw({
     canvasRef,
+    containerRef,
     height,
     miniMapWidth,
     leftDiff,
@@ -98,6 +99,7 @@ export const DiffMinimap: React.FC<DiffMinimapProps> = ({
   return (
     <div
       ref={containerRef}
+      className="minimap-wrapper"
       style={{
         width: miniMapWidth,
         height,

--- a/src/components/DiffViewer/components/ViewerRow.tsx
+++ b/src/components/DiffViewer/components/ViewerRow.tsx
@@ -28,6 +28,9 @@ function ViewerRow({
         <button onClick={() => onExpand(originalLeftLine.segmentIndex)} className="text-blue-500 underline">
           Show Hidden Lines
         </button>
+        <button onClick={() => onExpand(originalLeftLine.segmentIndex)} className="text-blue-500 underline">
+          Show Hidden Lines
+        </button>
       </div>
     );
   }

--- a/src/components/DiffViewer/components/VirtualizedDiffViewer.tsx
+++ b/src/components/DiffViewer/components/VirtualizedDiffViewer.tsx
@@ -23,6 +23,7 @@ export const VirtualizedDiffViewer: React.FC<VirtualizedDiffViewerProps> = ({
   leftTitle,
   rightTitle,
   hideSearch,
+  showSingleMinimap,
   onSearchMatch,
   differOptions,
   className,
@@ -194,7 +195,7 @@ export const VirtualizedDiffViewer: React.FC<VirtualizedDiffViewerProps> = ({
       </div>
 
       {/* List & Minimap */}
-      <div style={{ display: "flex", gap: "8px" }}>
+      <div style={{ display: "flex", gap: "8px", position: "relative" }}>
         <List
           ref={listRef}
           className="virtual-json-diff-list-container"
@@ -209,16 +210,34 @@ export const VirtualizedDiffViewer: React.FC<VirtualizedDiffViewerProps> = ({
           {ViewerRow}
         </List>
 
-        <DiffMinimap
-          leftDiff={leftView}
-          rightDiff={rightView}
-          height={height}
-          miniMapWidth={miniMapWidth}
-          currentScrollTop={scrollTop}
-          searchResults={searchState.results}
-          currentMatchIndex={searchState.currentIndex}
-          onScroll={scrollTop => listRef.current?.scrollTo(scrollTop)}
-        />
+        <div className="minimap-overlay">
+          <div className="half left-map-holder">
+            {!showSingleMinimap && (
+              <DiffMinimap
+                leftDiff={leftView}
+                rightDiff={rightView}
+                height={height}
+                miniMapWidth={miniMapWidth}
+                currentScrollTop={scrollTop}
+                searchResults={searchState.results}
+                currentMatchIndex={searchState.currentIndex}
+                onScroll={scrollTop => listRef.current?.scrollTo(scrollTop)}
+              />
+            )}
+          </div>
+          <div className="half right-map-holder">
+            <DiffMinimap
+              leftDiff={leftView}
+              rightDiff={rightView}
+              height={height}
+              miniMapWidth={miniMapWidth}
+              currentScrollTop={scrollTop}
+              searchResults={searchState.results}
+              currentMatchIndex={searchState.currentIndex}
+              onScroll={scrollTop => listRef.current?.scrollTo(scrollTop)}
+            />
+          </div>
+        </div>
       </div>
 
       {/* Hide All Expanded Lines Button */}

--- a/src/components/DiffViewer/hooks/useMinimapDraw.ts
+++ b/src/components/DiffViewer/hooks/useMinimapDraw.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import type { DiffRowOrCollapsed } from "../types";
 
@@ -64,45 +64,67 @@ export function useMinimapDraw({
     ctx.fillRect(x, y, width, ROW_HEIGHT);
   }, [ROW_HEIGHT]);
 
-  // Draw the differences -> This will be called in drawScrollBox method
-  const drawDifferencesInMinimap = useCallback((ctx: CanvasRenderingContext2D) => {
+  const diffCanvas = useMemo(() => {
+    const offscreen = document.createElement("canvas");
+    offscreen.width = miniMapWidth;
+    offscreen.height = height;
+    const ctx = offscreen.getContext("2d");
+    if (!ctx)
+      return null;
+
     const scale = height / totalLines;
 
-    if (currentMatchIndex >= 0 && searchResults[currentMatchIndex] !== undefined) {
-      const y = searchResults[currentMatchIndex] * scale;
-      const lineHeight = Math.max(1, scale);
-      ctx.fillStyle = CURRENT_MATCH_COLOR;
-      ctx.fillRect(0, y, miniMapWidth, lineHeight);
-    }
-
+    // left diff
     leftDiff.forEach((line, index) => {
       const y = index * scale;
       drawLine(ctx, line, y, 0, miniMapWidth / 2);
     });
 
+    // right diff
     rightDiff.forEach((line, index) => {
       const y = index * scale;
       drawLine(ctx, line, y, miniMapWidth / 2, miniMapWidth / 2);
     });
 
+    // search highlights
     searchResults.forEach((index) => {
       const y = index * scale;
       const lineHeight = Math.max(1, scale);
       ctx.fillStyle = SEARCH_HIGHLIGHT_COLOR;
       ctx.fillRect(0, y, miniMapWidth, lineHeight);
     });
-  }, [height, totalLines, currentMatchIndex, searchResults, leftDiff, rightDiff, miniMapWidth, drawLine]);
+
+    return offscreen;
+  }, [leftDiff, rightDiff, searchResults, height, totalLines, miniMapWidth, drawLine]);
 
   // Draw the scroll box and also differences in minimapo
-  const drawScrollBox = useCallback((ctx: CanvasRenderingContext2D, color: string) => {
-    const totalContentHeight = totalLines * ROW_HEIGHT;
-    const viewportTop = (currentScrollTop / totalContentHeight) * height;
+  const drawScrollBox = useCallback(
+    (ctx: CanvasRenderingContext2D, color: string) => {
+      if (!diffCanvas)
+        return;
 
-    drawDifferencesInMinimap(ctx);
+      // Copy pre-rendered diff
+      ctx.clearRect(0, 0, miniMapWidth, height);
+      ctx.drawImage(diffCanvas, 0, 0);
 
-    ctx.fillStyle = color;
-    ctx.fillRect(0, viewportTop, miniMapWidth, viewportHeight);
-  }, [totalLines, ROW_HEIGHT, currentScrollTop, height, drawDifferencesInMinimap, miniMapWidth, viewportHeight]);
+      // Draw scroll box
+      const totalContentHeight = totalLines * ROW_HEIGHT;
+      const viewportTop = (currentScrollTop / totalContentHeight) * height;
+
+      ctx.fillStyle = color;
+      ctx.fillRect(0, viewportTop, miniMapWidth, viewportHeight);
+
+      // Draw current match highlight (optional)
+      if (currentMatchIndex >= 0 && searchResults[currentMatchIndex] !== undefined) {
+        const scale = height / totalLines;
+        const y = searchResults[currentMatchIndex] * scale;
+        const lineHeight = Math.max(1, scale);
+        ctx.fillStyle = CURRENT_MATCH_COLOR;
+        ctx.fillRect(0, y, miniMapWidth, lineHeight);
+      }
+    },
+    [diffCanvas, currentScrollTop, totalLines, ROW_HEIGHT, height, miniMapWidth, viewportHeight, currentMatchIndex, searchResults],
+  );
 
   const drawMinimap = useCallback(() => {
     const canvas = canvasRef.current;

--- a/src/components/DiffViewer/hooks/useMinimapDraw.ts
+++ b/src/components/DiffViewer/hooks/useMinimapDraw.ts
@@ -13,6 +13,7 @@ const MINIMAP_SCROLL_COLOR = "#7B7B7B80";
 
 type Props = {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   height: number;
   miniMapWidth: number;
   leftDiff: DiffRowOrCollapsed[];
@@ -28,6 +29,7 @@ type Props = {
 
 export function useMinimapDraw({
   canvasRef,
+  containerRef,
   height,
   miniMapWidth,
   leftDiff,
@@ -138,9 +140,15 @@ export function useMinimapDraw({
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     if (!isDragging.current) {
+      if (containerRef.current) {
+        containerRef.current.style.opacity = "0.65";
+      }
       drawScrollBox(ctx, MINIMAP_SCROLL_COLOR);
     }
     else {
+      if (containerRef.current) {
+        containerRef.current.style.opacity = "0.85";
+      }
       drawScrollBox(ctx, MINIMAP_HOVER_SCROLL_COLOR);
     }
   }, [leftDiff, rightDiff, height, currentScrollTop, searchResults, currentMatchIndex, drawLine, viewportHeight]);

--- a/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
+++ b/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
@@ -323,7 +323,6 @@
   left: 0;
   width: 100%;
   display: flex;
-  pointer-events: none;
 }
 
 .diff-viewer-container .minimap-overlay .half {

--- a/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
+++ b/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
@@ -332,22 +332,19 @@
   align-items: center;
 }
 
-.diff-viewer-container .minimap-overlay .left {
+.diff-viewer-container .minimap-overlay .left-map-holder {
   justify-content: flex-end;
   min-width: 334px;
   margin-right: 10px;
 }
 
-.diff-viewer-container .minimap-overlay .right {
+.diff-viewer-container .minimap-overlay .right-map-holder {
   justify-content: flex-end;
-}
-
-.diff-viewer-container .minimap-overlay .item {
-  pointer-events: auto;
 }
 
 .diff-viewer-container .minimap-overlay .item .minimap-wrapper {
   opacity: 0.65;
+  pointer-events: auto;
 }
 
 .diff-viewer-container .minimap-overlay .item .minimap-wrapper:hover {

--- a/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
+++ b/src/components/DiffViewer/styles/JsonDiffCustomTheme.css
@@ -3,6 +3,7 @@
 }
 
 .virtual-json-diff-list-container {
+  scrollbar-width: none;
   --sb-track-color: #232e33;
   --sb-thumb-color: #4560f8;
   --sb-size: 6px;
@@ -38,6 +39,8 @@
 .json-diff-viewer.json-diff-viewer-theme-custom tr td.line-number {
   color: #999;
   padding: 2px;
+  padding-right: 6px;
+  text-align: right;
 }
 
 .json-diff-viewer.json-diff-viewer-theme-custom table {
@@ -68,7 +71,7 @@
   overflow: hidden;
   margin: 0;
   padding-left: 4px;
-  margin-right: 4px;
+  margin-right: 29px;
   font-size: 12px;
   min-width: 300px;
   line-height: var(--diff-row-height);
@@ -166,7 +169,7 @@
 .collapsed-button {
   display: flex;
   background-color: #262626;
-  justify-content: center;
+  justify-content: space-around;
   align-items: center;
 }
 
@@ -292,20 +295,61 @@
 
 .virtual-json-diff-list-container::-webkit-scrollbar {
   width: var(--sb-size);
+  display: none;
 }
 
 .virtual-json-diff-list-container::-webkit-scrollbar-track {
   background: var(--sb-track-color);
+  display: none;
   border-radius: 3px;
 }
 
 .virtual-json-diff-list-container::-webkit-scrollbar-thumb {
   background: var(--sb-thumb-color);
   border-radius: 3px;
+  display: none;
 }
 
 @supports not selector(::-webkit-scrollbar) {
   .virtual-json-diff-list-container {
     scrollbar-color: var(--sb-thumb-color) var(--sb-track-color);
   }
+}
+
+/* MINIMAP IMPROVEMENTS */
+.diff-viewer-container .minimap-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  pointer-events: none;
+}
+
+.diff-viewer-container .minimap-overlay .half {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.diff-viewer-container .minimap-overlay .left {
+  justify-content: flex-end;
+  min-width: 334px;
+  margin-right: 10px;
+}
+
+.diff-viewer-container .minimap-overlay .right {
+  justify-content: flex-end;
+}
+
+.diff-viewer-container .minimap-overlay .item {
+  pointer-events: auto;
+}
+
+.diff-viewer-container .minimap-overlay .item .minimap-wrapper {
+  opacity: 0.65;
+}
+
+.diff-viewer-container .minimap-overlay .item .minimap-wrapper:hover {
+  opacity: 0.85;
 }

--- a/src/components/DiffViewer/types/index.ts
+++ b/src/components/DiffViewer/types/index.ts
@@ -42,6 +42,7 @@ export type VirtualizedDiffViewerProps = {
   rightTitle?: string;
   onSearchMatch?: (index: number) => void;
   differOptions?: DifferOptions;
+  showSingleMinimap?: boolean;
   className?: string;
   miniMapWidth?: number;
   inlineDiffOptions?: InlineDiffOptions;


### PR DESCRIPTION
This PR improves the performance and usability of the diff viewer by:

- Precomputing and rendering the diff once to an offscreen canvas.
- Using the precomputed diff to display two identical minimaps on both sides of the viewer.
- Reducing unnecessary redraws during scrolling, search highlighting, and diff updates.
- Maintaining full interactivity (click/drag) on both minimaps while keeping the overlay lightweight.

This change significantly reduces CPU usage and ensures smoother scrolling and interactions, especially for large files.

New viewer will look like this. Performance increase made scrollbox move smoother.
 
<img width="1011" height="481" alt="image" src="https://github.com/user-attachments/assets/3790c025-3c39-4328-a1b9-e5b18651dea0" />

